### PR TITLE
Update EnchantmentBehavior.cs

### DIFF
--- a/krpgenchantment/src/Behaviors/EnchantmentBehavior.cs
+++ b/krpgenchantment/src/Behaviors/EnchantmentBehavior.cs
@@ -77,6 +77,13 @@ namespace KRPGLib.Enchantment
         }
         public override void OnHeldInteractStop(float secondsUsed, ItemSlot slot, EntityAgent byEntity, BlockSelection blockSel, EntitySelection entitySel, ref EnumHandling handling)
         {
+            // Defensive null checks
+            if (slot == null || slot.Itemstack == null || slot.Itemstack.Collectible == null)
+            {
+                base.OnHeldInteractStop(secondsUsed, slot, byEntity, blockSel, entitySel, ref handling);
+                return;
+            }
+
             // Specific use on self for KRPG Wands
             if (secondsUsed < 1 || slot.Itemstack.Collectible.Class != "WandItem") return;
 


### PR DESCRIPTION
Check for null in the event that the item is missing/used up when OnHeldInteractStop is called

Built and tested in 1.21.0
Verified exception no longer thrown when putting honey in a bucket
Did not test to ensure that wand functionality still works but don't see a reason that it wouldn't since this is just a null check before the currently implemented code