### PR TITLE
Beta

### DIFF
--- a/krpgenchantment/assets/krpgenchantment/blocktypes/chargingtable.json
+++ b/krpgenchantment/assets/krpgenchantment/blocktypes/chargingtable.json
@@ -14,7 +14,7 @@
   "variantgroups": [
     {
       "code": "wood",
-      "states": [ "aged" ],
+      "states": ["aged"],
       "loadFromProperties": "block/wood"
     },
     {
@@ -31,7 +31,11 @@
   },
   "attributes": {
     "reinforcable": true,
-    "propickable": true,
+    "propickable": false,
+    "handbook": {
+			"excludeByType": { 
+        "*-east": true, "*-west": true, "*-south": true}
+    },
     "drop": {
       "normal-generic": true
     }

--- a/krpgenchantment/assets/krpgenchantment/recipes/grid/block/chargingtable.json
+++ b/krpgenchantment/assets/krpgenchantment/recipes/grid/block/chargingtable.json
@@ -22,12 +22,12 @@
     },
     "H": {
       "type": "item",
-      "code": "game:hammer-*",
+      "tags": ["tool-hammer"],
       "isTool": true
     },
     "S": {
       "type": "item",
-      "code": "game:saw-*",
+      "tags": ["tool-saw"],
       "isTool": true
     }
   },

--- a/krpgenchantment/modinfo.json
+++ b/krpgenchantment/modinfo.json
@@ -4,7 +4,7 @@
   "name": "KRPGEnchantment",
   "authors": [ "BloodThunder" ],
   "description": "Adds magical enchantments to VS!",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "dependencies": {
     "game": ""
   }


### PR DESCRIPTION
-== Release 1.4.1 ==-

Fixed: Charging Table showing uncraftable variants in the Handbook.
Updated: Charging Table now uses the new "tags" based tool detection for greater tool compatibility in crafting.